### PR TITLE
Potential fix for code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/src/utils/proxy-server/proxy-server.js
+++ b/src/utils/proxy-server/proxy-server.js
@@ -40,6 +40,25 @@ app.post('/proxy', async (req, res) => {
             return res.status(400).json({ error: 'Falta el camp "url" al body' });
         }
 
+        // SSRF Mitigation: Allow-list hostnames
+        const ALLOWED_HOSTS = [
+            'api.example.com',
+            'data.example.net'
+            // Add further allowed hostnames as needed
+        ];
+        let parsedUrl;
+        try {
+            parsedUrl = new URL(url);
+        } catch (e) {
+            return res.status(400).json({ error: 'URL invàlida' });
+        }
+        if (!ALLOWED_HOSTS.includes(parsedUrl.hostname)) {
+            return res.status(403).json({ error: 'Host no autoritzat' });
+        }
+        if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+            return res.status(400).json({ error: 'Protocol no suportat' });
+        }
+
         // Serialize body only if Content-Type is application/json and body is not a string
         const formattedBody =
             headers['Content-Type'] === 'application/json' && typeof body !== 'string'


### PR DESCRIPTION
Potential fix for [https://github.com/trevSmart/NextBank/security/code-scanning/2](https://github.com/trevSmart/NextBank/security/code-scanning/2)

To fix this SSRF vulnerability, we should avoid using untrusted user input as the request host. The best approach is to allow proxying only to a predefined allow-list of domains (and/or restrict based on URL structure), where the user input is used only to select among known safe options.  
- Construct an allow-list (array) of safe hosts/domains for proxying, such as `["api.example.com", "data.example.net"]`.
- Parse the incoming `url` and extract the hostname. If the hostname is present in the allow-list, proceed; otherwise, reject the request with a suitable error.
- Optionally, also check that the protocol is "http" or "https".
- This change should be made within the `/proxy` POST handler (lines 35–60).
- To implement this, we need to parse the URL for the hostname (`new URL(url)`), compare it to the allow-list, and adjust error handling to reject unallowed requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
