### PR TITLE
Improve styling of important agent chat messages

### DIFF
--- a/src/components/agentforceClient/script.js
+++ b/src/components/agentforceClient/script.js
@@ -439,21 +439,21 @@ const ChatWidget = {
 		const messageAvatar = document.createElement('div');
 		messageAvatar.className = 'message-avatar';
 		// messageAvatar.draggable = false;
-		if (message.type === 'agent' || message.type === 'typing') {
-			const avatarImg = document.createElement('img');
-			avatarImg.src = '/src/assets/images/agent_astro.svg';
-			avatarImg.alt = 'Agent Avatar';
-			avatarImg.className = 'agent-avatar';
-			avatarImg.title = 'Agentforce';
-			avatarImg.draggable = false;
-			messageAvatar.appendChild(avatarImg);
+                if (message.type === 'agent' || message.type === 'agentImportant' || message.type === 'typing') {
+                        const avatarImg = document.createElement('img');
+                        avatarImg.src = '/src/assets/images/agent_astro.svg';
+                        avatarImg.alt = 'Agent Avatar';
+                        avatarImg.className = 'agent-avatar';
+                        avatarImg.title = 'Agentforce';
+                        avatarImg.draggable = false;
+                        messageAvatar.appendChild(avatarImg);
 
-			if (message.type === 'agent') {
-				const messageName = document.createElement('div');
-				messageName.className = 'message-name';
-				messageName.textContent = message.name;
-				messageContent.appendChild(messageName);
-			}
+                        if (message.type === 'agent' || message.type === 'agentImportant') {
+                                const messageName = document.createElement('div');
+                                messageName.className = 'message-name';
+                                messageName.textContent = message.name;
+                                messageContent.appendChild(messageName);
+                        }
 		} else {
 			const userAvatar = document.createElement('div');
 			userAvatar.className = 'user-avatar';

--- a/src/components/agentforceClient/style.css
+++ b/src/components/agentforceClient/style.css
@@ -250,7 +250,14 @@
     background: lightcoral;
     border: 1px solid #ff9800;
     box-shadow: 0 2px 8px rgba(255, 152, 0, 0.2);
+    border-radius: 1.2rem 0 1.2rem 1.2rem;
+    padding: 1rem 1.25rem;
+    color: #ffffff;
     animation: subtle-pulse 3s infinite;
+}
+
+.message.agentImportant .message-time {
+    color: rgba(255, 255, 255, 0.85);
 }
 
 @keyframes subtle-pulse {
@@ -619,7 +626,14 @@
     background: lightcoral;
     border: 1px solid #ff9800;
     box-shadow: 0 2px 8px rgba(255, 152, 0, 0.2);
+    border-radius: 1.2rem 0 1.2rem 1.2rem;
+    padding: 0.8rem 1rem 0.8rem 1rem;
+    color: #ffffff;
     animation: subtle-pulse 3s infinite;
+}
+
+.dashboard-card.assistant .message.agentImportant .message-time {
+    color: rgba(255, 255, 255, 0.85);
 }
 
 .dashboard-card.assistant .message-avatar {

--- a/src/components/agentforceClient/style.css
+++ b/src/components/agentforceClient/style.css
@@ -627,7 +627,7 @@
     border: 1px solid #ff9800;
     box-shadow: 0 2px 8px rgba(255, 152, 0, 0.2);
     border-radius: 1.2rem 0 1.2rem 1.2rem;
-    padding: 0.8rem 1rem 0.8rem 1rem;
+    padding: 0.8rem 1rem;
     color: #ffffff;
     animation: subtle-pulse 3s infinite;
 }


### PR DESCRIPTION
## Summary
- ensure important agent messages render with the agent avatar and label
- refresh styling for important message bubbles with padding, rounded corners, and readable colors in both chat contexts

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5e365670083298ac92e97c36f59c4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `agentImportant` messages show the agent avatar/name and apply updated bubble styling (padding, rounded corners, white text, time color) in chat and dashboard.
> 
> - **Chat Rendering**:
>   - Include `agentImportant` in avatar/name rendering logic in `src/components/agentforceClient/script.js` so important messages display the agent avatar and label.
> - **Styling**:
>   - Update `src/components/agentforceClient/style.css` for `agentImportant` bubbles:
>     - Add border-radius, padding, and white text color for `.message.agentImportant .message-content`.
>     - Adjust `.message-time` color for better contrast.
>   - Mirror these style updates under `.dashboard-card.assistant` for dashboard chat.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17fc4f97269fb19e708dcf5e8b5349fbe2399864. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->